### PR TITLE
Prevent line-deleting glitch

### DIFF
--- a/zui-event-loop
+++ b/zui-event-loop
@@ -410,7 +410,7 @@ else # No hyperlinks, and text_mode is off|hyp
     (( ${+functions[-zui-standard-text-select-callback]} )) && -zui-standard-text-select-callback "line" "$ZUILIST_WRAPPER_LINE"
     if [[ -z "$ZUILIST_WRAPPER_LINE" || "${ZUI[select_mode]}" = "quit" ]]; then
         REPLY="$ZUILIST_WRAPPER_LINE"
-        zle && { zle .redisplay; zle .reset-prompt; }
+        zle && { zle -R; zle .reset-prompt; }
         return 0
     fi
     zuiel_line_set=1


### PR DESCRIPTION
I use `zbrowse` with ZUI, and I've noticed that when I invoke it with `C-b` and while using a multiline prompt, earlier lines of terminal output are deleted:

[![asciicast](https://asciinema.org/a/UL0J9KnFtWmh00ZhDX8qV7Wel.svg)](https://asciinema.org/a/UL0J9KnFtWmh00ZhDX8qV7Wel)

Changing one instance of `zle .redisplay` in zdharma/zui to `zle -R` fixes the problem entirely.

Are there any undesirable side-effects to making this change?